### PR TITLE
Possible bugfix in Shapiro code

### DIFF
--- a/R/shapiro.R
+++ b/R/shapiro.R
@@ -45,11 +45,11 @@ shapiro <- function(file) {
         shapiro = matrix(rep(NA, ncol(n.x)))
         for (q in 1:ncol(name)) {
             notAlist = c()
-            notAlist = matrix(unlist(name[, q]))
+            notAlist = as.numeric(matrix(unlist(name[, q])))
             if (diff(range(notAlist)) == 0) {
                 shapiro[q, ] = NA
             } else {
-                shapiro[q, ] = shapiro.test(as.numeric(notAlist))$p.value
+                shapiro[q, ] = shapiro.test(notAlist)$p.value
             }
             assign(shapname, shapiro)
         }

--- a/R/statAnalysis.R
+++ b/R/statAnalysis.R
@@ -68,9 +68,9 @@ statAnalysis <- function(file, Frule = 0.8, normM = "NONE", imputeM = "KNN", glo
     
     imdat <- dat[, 3:ncol(dat)]
     
-    #if (length(imdat[imdat < 0L]) > 0) {
-    #    imdat[imdat < 0L] <- 0L
-    #}
+    if (length(imdat[imdat < 0L]) > 0) {
+        imdat[imdat < 0L] <- 0L
+    }
     imdat[imdat == 0L] <- NA
     
     imdat <- cbind(dat[, 1:2], imdat)

--- a/R/statAnalysis.R
+++ b/R/statAnalysis.R
@@ -68,9 +68,9 @@ statAnalysis <- function(file, Frule = 0.8, normM = "NONE", imputeM = "KNN", glo
     
     imdat <- dat[, 3:ncol(dat)]
     
-    if (length(imdat[imdat < 0L]) > 0) {
-        imdat[imdat < 0L] <- 0L
-    }
+    #if (length(imdat[imdat < 0L]) > 0) {
+    #    imdat[imdat < 0L] <- 0L
+    #}
     imdat[imdat == 0L] <- NA
     
     imdat <- cbind(dat[, 1:2], imdat)


### PR DESCRIPTION
Hi,

I believe I encountered a small bug in the Shapiro code. 

I'm not quite sure about the exact failure conditions, since I've been working off my own branch for a bit now. But I've encountered scenarios where the code throws an error because diff(range(notAlist)) somehow returns NA (instead of a numeric value). Moving the numeric conversion of notAlist up by a few lines of code to avoid this should be generally beneficial without any downsides I can see.